### PR TITLE
Restore mistakenly reverted code.

### DIFF
--- a/playbooks/byo/openshift-cluster/upgrades/v3_1_to_v3_2/upgrade.yml
+++ b/playbooks/byo/openshift-cluster/upgrades/v3_1_to_v3_2/upgrade.yml
@@ -4,6 +4,10 @@
   become: no
   gather_facts: no
   tasks:
+  - name: Verify Ansible version is greater than or equal to 1.9.4 and less than 2.0
+    fail:
+      msg: "Unsupported ansible version: {{ ansible_version }} found."
+    when: ansible_version.full | version_compare('1.9.4', 'lt') or ansible_version.full | version_compare('2.0', 'ge')
   - include_vars: ../../../../byo/openshift-cluster/cluster_hosts.yml
   - add_host:
       name: "{{ item }}"

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -28,17 +28,17 @@
     state: directory
     mode: 0700
 
-- name: Disable system etcd when containerized
-  when: etcd_is_containerized | bool
-  service:
-    name: etcd
-    state: stopped
-    enabled: no
-
 - name: Check for etcd service presence
   command: systemctl show etcd.service
   register: etcd_show
   changed_when: false
+
+- name: Disable system etcd when containerized
+  when: etcd_is_containerized | bool and 'LoadState=not-found' not in etcd_show.stdout
+  service:
+    name: etcd
+    state: stopped
+    enabled: no
 
 - name: Mask system etcd when containerized
   when: etcd_is_containerized | bool and 'LoadState=not-found' not in etcd_show.stdout

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -172,9 +172,14 @@
   register: start_result
   notify: Verify API Server
 
-- name: Stop and disable non HA master when running HA
+- name: Check for non-HA master service presence
+  command: systemctl show {{ openshift.common.service_type }}-master.service
+  register: master_svc_show
+  changed_when: false
+
+- name: Stop and disable non-HA master when running HA
   service: name={{ openshift.common.service_type }}-master enabled=no state=stopped
-  when: openshift_master_ha | bool
+  when: openshift_master_ha | bool and 'LoadState=not-found' not in master_svc_show.stdout
 
 - set_fact:
     master_service_status_changed: "{{ start_result | changed }}"


### PR DESCRIPTION
I did the service check fix in this branch originally, then cherry picked it out, squashed and submitted separately, and then I think reverted the orig two commits here so I could merge in the new commit from master. Somewhere in this mess I got it wrong. :)

Also restores the ansible check, I'm pretty sure it's a dupe but it's harmless.
